### PR TITLE
feat(speaking): add Talks & Videos section with click-to-load YouTube…

### DIFF
--- a/src/components/LiteYouTube.jsx
+++ b/src/components/LiteYouTube.jsx
@@ -1,0 +1,93 @@
+import React, { useState, useCallback } from 'react';
+
+/**
+ * LiteYouTube — click-to-load YouTube facade (no iframe until user clicks).
+ *
+ * Renders a lazy-loaded thumbnail from i.ytimg.com with a play button.
+ * On first pointer/focus interaction it warms up connections (preconnect),
+ * and only injects the real iframe after an explicit click/keypress.
+ *
+ * @param {string} id     - YouTube video ID
+ * @param {string} title  - Accessible video title
+ * @param {string} className - Extra classes for the wrapper
+ */
+
+let preconnected = false;
+function warmConnections() {
+  if (preconnected) return;
+  preconnected = true;
+  ['https://www.youtube-nocookie.com', 'https://www.google.com'].forEach((origin) => {
+    const link = document.createElement('link');
+    link.rel = 'preconnect';
+    link.href = origin;
+    document.head.appendChild(link);
+  });
+}
+
+export default function LiteYouTube({ id, title, className = '' }) {
+  const [activated, setActivated] = useState(false);
+  const [thumbQuality, setThumbQuality] = useState('maxresdefault');
+
+  const activate = useCallback(() => setActivated(true), []);
+
+  // maxresdefault doesn't exist for every video. YouTube either 404s (onError)
+  // or serves a 120x90 gray placeholder (detected via naturalWidth onLoad).
+  // hqdefault always exists, so fall back to it.
+  const fallbackToHq = useCallback(() => {
+    setThumbQuality((q) => (q === 'maxresdefault' ? 'hqdefault' : q));
+  }, []);
+
+  if (activated) {
+    return (
+      <div className={`relative w-full aspect-video rounded-xl overflow-hidden bg-black ${className}`}>
+        <iframe
+          className="absolute inset-0 w-full h-full"
+          src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=1&rel=0`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={activate}
+      onPointerOver={warmConnections}
+      onFocus={warmConnections}
+      className={`group relative w-full aspect-video rounded-xl overflow-hidden bg-black/60 border border-white/10 hover:border-white/25 transition-colors motion-reduce:transition-none focus:outline-none focus:ring-2 focus:ring-[#00e5ff]/50 cursor-pointer ${className}`}
+      aria-label={`Play video: ${title}`}
+    >
+      <img
+        src={`https://i.ytimg.com/vi/${id}/${thumbQuality}.jpg`}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        onError={fallbackToHq}
+        onLoad={(e) => {
+          if (e.currentTarget.naturalWidth <= 120) fallbackToHq();
+        }}
+        className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+      />
+      {/* Dark gradient for legibility */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" aria-hidden="true" />
+      {/* Play button */}
+      <span
+        className="absolute inset-0 flex items-center justify-center"
+        aria-hidden="true"
+      >
+        <span className="w-14 h-14 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 flex items-center justify-center transition-all duration-300 group-hover:bg-red-600/90 group-hover:scale-110 motion-reduce:transition-none motion-reduce:group-hover:scale-100">
+          <svg viewBox="0 0 24 24" className="w-6 h-6 fill-white ml-0.5">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </span>
+      </span>
+      {/* Title bar */}
+      <span className="absolute bottom-0 left-0 right-0 p-3 text-left">
+        <span className="text-xs font-bold text-white leading-snug line-clamp-2">{title}</span>
+      </span>
+    </button>
+  );
+}

--- a/src/pages/SpeakingPage.jsx
+++ b/src/pages/SpeakingPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import SEOHead from '../components/SEOHead';
 import Icon from '../components/Icon';
 import BrandBadge from '../components/BrandBadge';
+import LiteYouTube from '../components/LiteYouTube';
 
 const pastEvents = [
   { title: 'Cloud Native Community Day — Chattogram', org: 'CNCF Cloud Native Chattogram', date: '2025', url: 'https://ocgroups.dev/cncf/group/zjrcuw4/event/j3nrmeg', brand: 'cncf', color: '#446CE3' },
@@ -10,6 +11,15 @@ const pastEvents = [
   { title: 'Cloud Native Bangladesh — Community Event', org: 'CNCF Cloud Native Bangladesh', date: '2025', url: 'https://ocgroups.dev/cncf/group/w9fz6fg/event/9ghz5ad', brand: 'cncf', color: '#446CE3' },
   { title: 'AWS Student Builder Group — BRAC University Meetup', org: 'AWS SBG BRACU', date: '2025', url: 'https://www.meetup.com/aws-sbg-brac-university/events/311703434/', brand: 'aws', color: '#FF9900' },
   { title: 'AWS Student Builder Group — Cloud Workshop', org: 'AWS SBG BRACU', date: '2024', url: 'https://www.meetup.com/aws-sbg-brac-university/events/303548382/', brand: 'aws', color: '#FF9900' },
+];
+
+// Talks & Videos — YouTube video IDs from youtube.com/@zaynulabedinmiah.
+// To add a video: grab the ID from the URL (youtube.com/watch?v=<ID>) and append here.
+const talks = [
+  { id: 'syLzvMYkfBc', title: 'How We Built the Future of Environmental Protection | Google Maps + AI' },
+  { id: 'dLxiK394WOc', title: 'The Hidden Blueprint to AGI: A Multimodal Gemini Agent' },
+  { id: '-7WkS0ogs-k', title: 'LIVE: Build Your Own Video Streaming Platform (Like Netflix/YouTube) | AWS Cloud Workshop' },
+  { id: '1peij6j4t1g', title: 'AlexNet Explained: How the 2012 Paper That Changed AI Forever Still Matters Today' },
 ];
 
 const speakingTopics = [
@@ -77,6 +87,35 @@ export default function SpeakingPage() {
               </a>
             ))}
           </div>
+        </section>
+
+        {/* Talks & Videos */}
+        <section className="mb-12 motion-safe:animate-fade-in-up" aria-labelledby="talks-videos-heading">
+          <h2 id="talks-videos-heading" className="text-xl font-bold mb-4 flex items-center gap-3">
+            <span className="w-1.5 h-6 bg-red-500 rounded-full"></span>
+            Talks &amp; Videos
+          </h2>
+          <p className="text-sm text-gray-400 mb-6">
+            Session recordings and demos. Click a thumbnail to load and play the video.
+          </p>
+
+          {/* Facade-pattern video grid — no iframe loads until clicked */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {talks.map((video) => (
+              <LiteYouTube key={video.id} id={video.id} title={video.title} />
+            ))}
+          </div>
+
+          <a
+            href="https://www.youtube.com/@zaynulabedinmiah"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 mt-6 text-sm text-gray-400 hover:text-white transition-colors min-h-[44px] motion-reduce:transition-none"
+            aria-label="View all videos on YouTube channel"
+          >
+            <Icon name="youtube" className="text-red-500" /> View all videos on YouTube
+            <Icon name="external-link" className="text-xs" />
+          </a>
         </section>
 
         {/* Topics I'm Exploring */}


### PR DESCRIPTION
… facade

- LiteYouTube component: no iframe until clicked, lazy thumbnails with maxresdefault->hqdefault fallback, preconnect warm-up on hover/focus, prefers-reduced-motion respected
- SpeakingPage: responsive 2-col facade grid with 4 channel videos + channel link
- Hero and LCP untouched; Speaking route remains lazy-loaded