### PR TITLE
feat(seo): complete sameAs profile set and add hasCredential to Perso…

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         {
           "@type": "Organization",
           "name": "AWS Community Builders",
-          "sameAs": "https://aws.amazon.com/developer/community/community-builders/"
+          "sameAs": "https://builder.aws.com/community/community-builders"
         },
         {
           "@type": "Organization",
@@ -80,15 +80,61 @@
         {
           "@type": "Organization",
           "name": "Agentic AI Foundation",
-          "sameAs": "https://aaif.io/"
+          "sameAs": "https://aaif.io/ambassadors/"
         }
       ],
       "sameAs": [
         "https://github.com/azaynul10",
         "https://www.linkedin.com/in/zaynul-abedin-miah/",
         "https://www.youtube.com/@zaynulabedinmiah",
+        "https://x.com/azaynul123",
+        "https://www.facebook.com/azaynul123",
+        "https://dev.to/azaynul10",
+        "https://builder.aws.com/community/@zaynul10",
         "https://www.credly.com/users/zaynul-abedin-miah.65b5cd8c",
         "https://www.cncf.io/people/ambassadors/?p=zaynul-abedin-miah"
+      ],
+      "hasCredential": [
+        {
+          "@type": "EducationalOccupationalCredential",
+          "name": "CNCF Ambassador",
+          "credentialCategory": "Ambassador Program",
+          "recognizedBy": {
+            "@type": "Organization",
+            "name": "Cloud Native Computing Foundation"
+          },
+          "url": "https://www.credly.com/badges/772e6b5c-486a-4891-89b6-bf8bf4b55c39"
+        },
+        {
+          "@type": "EducationalOccupationalCredential",
+          "name": "PyTorch Ambassador",
+          "credentialCategory": "Ambassador Program",
+          "recognizedBy": {
+            "@type": "Organization",
+            "name": "PyTorch Foundation"
+          },
+          "url": "https://www.credly.com/badges/99087d47-e21a-4c5e-b934-01d2c98e991e"
+        },
+        {
+          "@type": "EducationalOccupationalCredential",
+          "name": "AWS Cloud Club Captain — Diamond Level",
+          "credentialCategory": "Community Program",
+          "recognizedBy": {
+            "@type": "Organization",
+            "name": "Amazon Web Services"
+          },
+          "url": "https://www.credly.com/badges/ec2c7d7c-394a-4122-881c-4a160d538b2e"
+        },
+        {
+          "@type": "EducationalOccupationalCredential",
+          "name": "Microsoft Certified: Azure AI Fundamentals (AI-900)",
+          "credentialCategory": "Certification",
+          "recognizedBy": {
+            "@type": "Organization",
+            "name": "Microsoft"
+          },
+          "url": "https://learn.microsoft.com/api/credentials/share/en-us/ZaynulAbedinMiah-6537/5465F864D4930A8?sharingId=68C4BF49E5BB256D"
+        }
       ],
       "knowsAbout": [
         "Agentic AI",


### PR DESCRIPTION
…n JSON-LD

- sameAs 5 -> 9: add X, Facebook, DEV Community, AWS Builder Center profile
- Add hasCredential with 4 verifiable person-specific credential URLs (CNCF Ambassador, PyTorch Ambassador, AWS Cloud Club Captain, Azure AI-900)
- Point AAIF memberOf at the ambassadors directory and AWS Community Builders at builder.aws.com